### PR TITLE
Add additional binning scheme and HFpt correlation plots

### DIFF
--- a/Bjets/MCSimpleEff.C
+++ b/Bjets/MCSimpleEff.C
@@ -293,6 +293,8 @@ void MCSimpleEff(int NumEvts = -1, int dataset = 91599,
     TH2D *h2_num_efficiency_jtr = new TH2D("num_efficiency_jtr", "",  jtbinsize, jt_binedges, rbinsize, r_binedges);
     TH2D *h2_denom_efficiency_jtr = new TH2D("denom_efficiency_jtr", "",  jtbinsize, jt_binedges, rbinsize, r_binedges);
     
+    
+    
     // 2D and 4D Observables response Matrices (286 - 292)
     RooUnfoldResponse *response_zjt = new RooUnfoldResponse( h2_zjt, h2_zjt_truth, "response_zjt" );
     RooUnfoldResponse *response_zr = new RooUnfoldResponse( h2_zr, h2_zr_truth, "respose_zr");
@@ -405,6 +407,14 @@ void MCSimpleEff(int NumEvts = -1, int dataset = 91599,
     TH2D *h2_purity_ptr = new TH2D("purity_ptr", "", rbinsize, r_binedges,  ptbinsize, pt_binedges );
     
     RooUnfoldResponse *response_ptr = new RooUnfoldResponse(h2_ptr, h2_truthptr, "response_ptr");
+    
+    
+    TH3D *h3_denom_efficiency_ptzjt_50_100 = new TH3D("denom_efficiency_ptzjt_50_100", "", zbinsize_50_100, z_binedges_50_100, jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges );   
+    TH3D *h3_denom_efficiency_ptzr_50_100 = new TH3D("denom_efficiency_ptzr_50_100", "",  zbinsize_50_100, z_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );    
+    TH3D *h3_denom_efficiency_ptjtr_50_100 = new TH3D("denom_efficiency_ptjtr_50_100", "",  jtbinsize_50_100, jt_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize,  pt_binedges );    
+    TH2D *h2_denom_efficiency_ptz_50_100 = new TH2D("denom_efficiency_ptz_50_100", "", zbinsize_50_100, z_binedges_50_100, ptbinsize, pt_binedges );   
+    TH2D *h2_denom_efficiency_ptjt_50_100 = new TH2D("denom_efficiency_ptjt_50_100", "", jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges);     
+    TH2D *h2_denom_efficiency_ptr_50_100 = new TH2D("denom_efficiency_ptr_50_100", "", rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges);    
     
     TH2D *h2_SVTag_eff_denom = new TH2D("h2_SVTag_eff_denom","", ptHFbinsize, ptHF_binedges, customptbinsize, custompt_binedges);
     TH2D *h2_SVTag_eff_denom_z = new TH2D("h2_SVTag_eff_denom_z","", zbinsize, z_binedges, customptbinsize, custompt_binedges);
@@ -654,6 +664,14 @@ void MCSimpleEff(int NumEvts = -1, int dataset = 91599,
             h3_denom_efficiency_ptzjt->Fill(truth_z, truth_jt, jet_pt);
             h3_denom_efficiency_ptzr->Fill(truth_z, truth_r, jet_pt);
             h3_denom_efficiency_ptjtr->Fill(truth_jt, truth_r, jet_pt);
+            
+            h2_denom_efficiency_ptz_50_100->Fill(truth_z, jet_pt);
+            h2_denom_efficiency_ptjt_50_100->Fill(truth_jt, jet_pt);
+            h2_denom_efficiency_ptr_50_100->Fill(truth_r, jet_pt);
+    
+            h3_denom_efficiency_ptzjt_50_100->Fill(truth_z, truth_jt, jet_pt);
+            h3_denom_efficiency_ptzr_50_100->Fill(truth_z, truth_r, jet_pt);
+            h3_denom_efficiency_ptjtr_50_100->Fill(truth_jt, truth_r, jet_pt);            
             
             h1_denom_efficiency_z->Fill(truth_z);
             h1_denom_efficiency_jt->Fill(truth_jt);

--- a/Bjets/MCSimpleObservables.C
+++ b/Bjets/MCSimpleObservables.C
@@ -183,6 +183,14 @@ void MCSimpleObservables(int NumEvts = -1, int dataset = 91599,
     TH3D *h3_ptzr = new TH3D("ptzr", "",  zbinsize, z_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
     TH3D *h3_ptjtr = new TH3D("ptjtr", "",  jtbinsize, jt_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
     
+    TH2D *h2_ptz_50_100 = new TH2D("ptz_50_100", ";z;", zbinsize_50_100, z_binedges_50_100, ptbinsize, pt_binedges);
+    TH2D *h2_ptjt_50_100 = new TH2D("ptjt_50_100", ";j_{T};", jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges);
+    TH2D *h2_ptr_50_100 = new TH2D("ptr_50_100", ";r;", rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges);
+    
+    TH3D *h3_ptzjt_50_100 = new TH3D("ptzjt_50_100", "", zbinsize_50_100, z_binedges_50_100, jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_ptzr_50_100 = new TH3D("ptzr_50_100", "",  zbinsize_50_100, z_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_ptjtr_50_100 = new TH3D("ptjtr_50_100", "",  jtbinsize_50_100, jt_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );    
+    
     TH3D *h3_ptzjt_gluon = new TH3D("ptzjt_gluon", "", zbinsize, z_binedges, jtbinsize, jt_binedges, ptbinsize, pt_binedges );
     TH3D *h3_ptzr_gluon = new TH3D("ptzr_gluon", "",  zbinsize, z_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
     TH3D *h3_ptjtr_gluon = new TH3D("ptjtr_gluon", "",  jtbinsize, jt_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
@@ -609,17 +617,25 @@ void MCSimpleObservables(int NumEvts = -1, int dataset = 91599,
       h2_ptjt->Fill(truth_jt, jet_pt);
       h2_ptr->Fill(truth_r, jet_pt);
       
-     h3_ptzjt->Fill(truth_z, truth_jt, jet_pt);
-     h3_ptzr->Fill(truth_z, truth_r, jet_pt);
-     h3_ptjtr->Fill(truth_jt, truth_r, jet_pt);
+      h3_ptzjt->Fill(truth_z, truth_jt, jet_pt);
+      h3_ptzr->Fill(truth_z, truth_r, jet_pt);
+      h3_ptjtr->Fill(truth_jt, truth_r, jet_pt);
       
-     h2_zjt->Fill(truth_z, truth_jt);
-     h2_zr->Fill(truth_z, truth_r);
-     h2_jtr->Fill(truth_jt, truth_r);
+      h2_ptz_50_100->Fill(truth_z, jet_pt);
+      h2_ptjt_50_100->Fill(truth_jt, jet_pt);
+      h2_ptr_50_100->Fill(truth_r, jet_pt);
       
-     h2_meas_zjt->Fill(meas_z, meas_jt);
-     h2_meas_zr->Fill(meas_z, meas_r);
-     h2_meas_jtr->Fill(meas_jt, meas_r);
+      h3_ptzjt_50_100->Fill(truth_z, truth_jt, jet_pt);
+      h3_ptzr_50_100->Fill(truth_z, truth_r, jet_pt);
+      h3_ptjtr_50_100->Fill(truth_jt, truth_r, jet_pt);      
+      
+      h2_zjt->Fill(truth_z, truth_jt);
+      h2_zr->Fill(truth_z, truth_r);
+      h2_jtr->Fill(truth_jt, truth_r);
+      
+      h2_meas_zjt->Fill(meas_z, meas_jt);
+      h2_meas_zr->Fill(meas_z, meas_r);
+      h2_meas_jtr->Fill(meas_jt, meas_r);
 
       // 2D Truth-Reco Correspondence (219 - 224)
 //      TH2D *h2_truthreco_z = new TH2D("truthreco_z", ";Reco z; Truth z", zbinsize, z_binedges, zbinsize, z_binedges);

--- a/Bjets/Settings.h
+++ b/Bjets/Settings.h
@@ -7,15 +7,6 @@
 #include <TTree.h>
 #include <TH1D.h>
 #include <TRandom3.h>
-//#include "fastjet/ClusterSequence.hh"
-//#include "fastjet/contrib/SoftDrop.hh"
-// #include "/afs/cern.ch/work/i/ichahrou/RooUnfold/src/RooUnfoldBayes.h"
-// #include "/afs/cern.ch/work/i/ichahrou/RooUnfold2.0.1/build/RooUnfoldResponse.h"
-
-// gSystem->AddIncludePath(" -I$HOME//fastjet-install/include");
-//     gSystem->Load("$HOME//fastjet-install/lib/libfastjet.so");
-
-//using namespace fastjet;
 
 bool pt_cut = true;
 bool Erad_cut = true;
@@ -102,11 +93,6 @@ float Erad_max = 1000.;
 float dR_min = 0.;
 float dR_max = 5.;
 
-// const int ktbinsize = 12;
-// const int dRbinsize = 11;
-// const int zbinsize = 13;
-// const int thetabinsize = 11;
-// const int Eradbinsize = 11;
 
 // const int ptbinsize = 2;
 // const int ptbinsize = 9; // more pt bins gives better unfolding for charged dist
@@ -130,35 +116,16 @@ const int neut_pbinsize = 9;
 const int ptbinsize_JES = 4;
 const int nTracksbinsize = 5;
 
-//const int zbinsize = 21; // N bins = len(binedges) - 1
-//const int jtbinsize = 20;
-//const int rbinsize = 25 ;
 
-const int zbinsize = 16;
+const int zbinsize = 15;
 const int jtbinsize = 18;
-const int rbinsize = 13;
+const int rbinsize = 12;
 
-const int zbinsize50100 = 11; // N bins = len(binedges) - 1
-const int jtbinsize50100 = 16;
-const int rbinsize50100 = 16 ;
-//const int rbinsize = 20 ;
-
-const int z0Bins = 27;  //PERFECT:45[55,53(Good),BETTER:52,51BEST: 50]
-const int z1Bins = 43;  //  BEST: 43 , GOOD: 45
-const int z2Bins = 25;  // BEST , BETTER: 25
-const int z3Bins = 10;  // BEST: 10 GOOD: 13, Really good: 9
-const int jt0Bins = 27;  // [BEST: 29! ] Good 30
-const int jt1Bins = 45;  //PERFECT : GOOD 45
-const int jt2Bins = 28;  // PERFECT: 28
-const int jt3Bins = 17;  //PERFECT: GOOD: 17
-const int r0Bins = 28;  //  and  GOOD 31 BEST: 28
-const int r1Bins = 28;  //
-const int r2Bins = 22;  /// GOOD: 22
-const int r3Bins = 20;  // Good: 20
+const int zbinsize_50_100 = 7; // N bins = len(binedges) - 1
+const int jtbinsize_50_100 = 10;
+const int rbinsize_50_100 = 6 ;
 
 
-//const int etabinsize = 10;
-//const int HFetabinsize = 10;
 
 //double ptHF_binedges[ptHFbinsize + 1] = {2, 5, 10, 15, 20, 25, 35, 50, 80, 150};
 double ptHF_binedges[ptHFbinsize + 1] = {0, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16, 18, 20, 25, 35, 100};
@@ -176,32 +143,19 @@ double pt_binedges[ptbinsize + 1] = {pTLow, 15, 20, 30, 50, 100.};
 double custompt_binedges[customptbinsize +1] = {pTLow, 15, 20, 30, 50, 100};
 double finept_binedges[fineptbinsize +1] = {pTLow, 15, 20, 30, 40, 50, 60, 70, 80, 100, 200};
 
-  // ptbinsize = 6
-// double pt_binedges[ptbinsize+1] = {15, 20, 40, 60, 80, 100, 120, 140, ptMax, 200};
-// double pt_binedges[ptbinsize+1] = {15, 20, ptMax};
 double longpt_binedges[longptbinsize + 1] = {15, 17, 20, 30, 40, 50, ptMax};
 double pt_binedges_truth[ptbinsize_truth + 1] = {15, 20, 30, 50, ptMax};
 double p_binedges[pbinsize + 1] = {2, 3, 4, 5, 7.5, 10, 12.5, 15, 20, 25, 30, 40, 50, 75, 100, 150, 200, 250, 300, 500, 1000};
 double neut_p_binedges[pbinsize + 1] = {2, 4, 10, 20, 40, 80, 160, 320, 640, 1280};
 double nTrack_binedges[nTracksbinsize + 1] = {0, 100, 200, 300, 400, 500};
 
-// 21, 20, 25
-//double z_binedges[zbinsize + 1] = {0.0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1.0, 1.1};
-//double jt_binedges[jtbinsize + 1 ] = {0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5, 10.0};
-//double r_binedges[rbinsize +1 ] = {0.0, 0.02, 0.04, 0.06, 0.08, 0.1, 0.12, 0.14, 0.16, 0.18, 0.2, 0.22, 0.24, 0.26, 0.28, 0.3, 0.32, 0.34, 0.36, 0.38, 0.4, 0.42, 0.44, 0.46, 0.48, 0.5 };
 
-
-double z_binedges[zbinsize + 1] = {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1.0, 1.1};
+double z_binedges[zbinsize + 1] = {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1.0};
 double jt_binedges[jtbinsize + 1 ] = {0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 6.0, 7.0, 8.0, 10.0};
-double r_binedges[rbinsize +1 ] = {0.0, 0.025, 0.05, 0.075, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6};
+double r_binedges[rbinsize +1 ] = {0.0, 0.025, 0.05, 0.075, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5};
 
-double z_50100binedges[zbinsize50100 + 1] = {0., 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1};
+double z_binedges_50_100[zbinsize_50_100 + 1] = {0.0, 0.1, 0.25, 0.4, 0.55, 0.7, 0.85, 1.0};
+double jt_binedges_50_100[jtbinsize_50_100 + 1 ] = {0.0, 0.5, 1.0, 1.50, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0};
+double r_binedges_50_100[rbinsize_50_100 +1 ] = {0.0, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5};
 
-float jt_Bwidth_50 = 0.625;
-float r_Bwidth_50 = 0.03125;
-
-double jt_50100binedges[jtbinsize50100 + 1 ] = {0.0, jt_Bwidth_50,  2*jt_Bwidth_50,  3.0*jt_Bwidth_50,  4.0*jt_Bwidth_50, 5.0*jt_Bwidth_50, 6.0*jt_Bwidth_50, 7.0*jt_Bwidth_50,  8.0*jt_Bwidth_50, 9.0*jt_Bwidth_50,  10.0*jt_Bwidth_50, 11*jt_Bwidth_50, 12*jt_Bwidth_50, 13*jt_Bwidth_50, 14*jt_Bwidth_50, 15*jt_Bwidth_50, 16*jt_Bwidth_50};
-
-double r_50100binedges[rbinsize50100 +1 ] = {0.0, r_Bwidth_50, 2*r_Bwidth_50, 3*r_Bwidth_50, 4*r_Bwidth_50, 5*r_Bwidth_50, 6*r_Bwidth_50, 7*r_Bwidth_50, 8*r_Bwidth_50, 9*r_Bwidth_50, 10*r_Bwidth_50, 11*r_Bwidth_50, 12*r_Bwidth_50, 13*r_Bwidth_50, 14*r_Bwidth_50, 15*r_Bwidth_50, 16*r_Bwidth_50 };
-//double r_binedges[rbinsize +1 ] = {0.0, 0.025, 0.050, 0.075, 0.1, 0.125, 0.150, 0.175, 0.2, 0.225, 0.250, 0.275, 0.3, 0.325, 0.350, 0.375, 0.4, 0.425,                                   0.450,0.475, 0.5};
  

--- a/Bjets/SimpleObservables.C
+++ b/Bjets/SimpleObservables.C
@@ -381,6 +381,14 @@ void SimpleObservables(int NumEvts = 10000, int dataset = 1510,
     TH3D *h3_ptzjt = new TH3D("ptzjt", ";z ; j_{T};", zbinsize, z_binedges, jtbinsize, jt_binedges, ptbinsize, pt_binedges );
     TH3D *h3_ptzr = new TH3D("ptzr", ";z ; r;",  zbinsize, z_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
     TH3D *h3_ptjtr = new TH3D("ptjtr", ";j_{T}; r; ",  jtbinsize, jt_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
+    
+    TH2D *h2_ptz_50_100 = new TH2D("ptz_50_100", ";z;", zbinsize_50_100, z_binedges_50_100, ptbinsize, pt_binedges);
+    TH2D *h2_ptjt_50_100 = new TH2D("ptjt_50_100", ";j_{T};", jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges);
+    TH2D *h2_ptr_50_100 = new TH2D("ptr_50_100", ";r;", rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges);
+    
+    TH3D *h3_ptzjt_50_100 = new TH3D("ptzjt_50_100", ";z ; j_{T};", zbinsize_50_100, z_binedges_50_100, jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_ptzr_50_100 = new TH3D("ptzr_50_100", ";z ; r;",  zbinsize_50_100, z_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_ptjtr_50_100 = new TH3D("ptjtr_50_100", ";j_{T}; r; ",  jtbinsize_50_100, jt_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );    
      
     TH3D *h3_ptzjt_unweight = new TH3D("ptzjt_unweight", "", zbinsize, z_binedges, jtbinsize, jt_binedges, ptbinsize, pt_binedges );
     TH3D *h3_ptzr_unweight = new TH3D("ptzr_unweight", "",  zbinsize, z_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
@@ -389,6 +397,13 @@ void SimpleObservables(int NumEvts = 10000, int dataset = 1510,
     TH3D *h3_ptHFzjt = new TH3D("ptHFzjt", "", zbinsize, z_binedges, jtbinsize, jt_binedges, ptHFbinsize, ptHF_binedges );
     TH3D *h3_ptHFzr = new TH3D("ptHFzr", "",  zbinsize, z_binedges, rbinsize, r_binedges, ptHFbinsize, ptHF_binedges );
     TH3D *h3_ptHFjtr = new TH3D("ptHFjtr", "",  jtbinsize, jt_binedges, rbinsize, r_binedges, ptHFbinsize, ptHF_binedges );
+    
+    TH2D *h2_ptHFz = new TH2D("HFptz", ";z;", zbinsize, z_binedges, ptHFbinsize, ptHF_binedges);
+    TH2D *h2_ptHFjt = new TH2D("HFptjt", ";j_{T};", jtbinsize, jt_binedges, ptHFbinsize, ptHF_binedges);
+    TH2D *h2_ptHFr = new TH2D("HFptr", ";r;", rbinsize, r_binedges, ptHFbinsize, ptHF_binedges);    
+
+    TH1D *h1_z_ptHFcut_g5 = new TH1D("z_ptHFcut_g5", ";z;", zbinsize, z_binedges);
+    TH1D *h1_z_ptHFcut_l5 = new TH1D("z_ptHFcut_l5", ";z;", zbinsize, z_binedges);    
     
     /// ------------------------------------------ COMBINATORIAL --------------------------------------------- ///
     
@@ -1251,6 +1266,22 @@ void SimpleObservables(int NumEvts = 10000, int dataset = 1510,
         h2_ptz->Fill(z, jet_pt, event_weight);
         h2_ptjt->Fill(jt, jet_pt, event_weight);
         h2_ptr->Fill(r, jet_pt, event_weight);
+        
+        h3_ptzjt_50_100->Fill(z, jt, jet_pt, event_weight);
+        h3_ptzr_50_100->Fill(z, r, jet_pt, event_weight);
+        h3_ptjtr_50_100->Fill(jt, r, jet_pt, event_weight);
+
+
+        h2_ptz_50_100->Fill(z, jet_pt, event_weight);
+        h2_ptjt_50_100->Fill(jt, jet_pt, event_weight);
+        h2_ptr_50_100->Fill(r, jet_pt, event_weight);        
+
+        h2_ptHFz->Fill(z, HF_pt);
+        h2_ptHFjt->Fill(jt, HF_pt);
+        h2_ptHFr->Fill(r, HF_pt);      
+        
+        if (HF_pt < 5.) { h1_z_ptHFcut_l5->Fill(z); }        
+        else { h1_z_ptHFcut_g5->Fill(z); }
 
       }
   

--- a/Bjets/SimpleUnfold.C
+++ b/Bjets/SimpleUnfold.C
@@ -256,6 +256,7 @@ void SimpleUnfold(int NumEvts = -1,
     TH2D *h2_denom_efficiency_zjt = (TH2D*)file_eff->Get("denom_efficiency_zjt");
     TH2D *h2_denom_efficiency_zr = (TH2D*)file_eff->Get("denom_efficiency_zr");
     TH2D *h2_denom_efficiency_jtr = (TH2D*)file_eff->Get("denom_efficiency_jtr");
+    
     TH2D *h2_denom_efficiency_ptz=(TH2D*)file_eff->Get("denom_efficiency_ptz");
     TH2D *h2_denom_efficiency_ptjt=(TH2D*)file_eff->Get("denom_efficiency_ptjt");
     TH2D *h2_denom_efficiency_ptr=(TH2D*)file_eff->Get("denom_efficiency_ptr");
@@ -264,7 +265,15 @@ void SimpleUnfold(int NumEvts = -1,
     TH3D *h3_denom_efficiency_ptzr=(TH3D*)file_eff->Get("denom_efficiency_ptzr");
     TH3D *h3_denom_efficiency_ptjtr=(TH3D*)file_eff->Get("denom_efficiency_ptjtr");
     
-     TH2D *h2_SVTag_eff_denom_z = (TH2D *)file_eff->Get("h2_SVTag_eff_denom_z");
+    TH2D *h2_denom_efficiency_ptz_50_100=(TH2D*)file_eff->Get("denom_efficiency_ptz_50_100");
+    TH2D *h2_denom_efficiency_ptjt_50_100=(TH2D*)file_eff->Get("denom_efficiency_ptjt_50_100");
+    TH2D *h2_denom_efficiency_ptr_50_100=(TH2D*)file_eff->Get("denom_efficiency_ptr_50_100");
+    
+    TH3D *h3_denom_efficiency_ptzjt_50_100=(TH3D*)file_eff->Get("denom_efficiency_ptzjt_50_100");
+    TH3D *h3_denom_efficiency_ptzr_50_100=(TH3D*)file_eff->Get("denom_efficiency_ptzr_50_100");
+    TH3D *h3_denom_efficiency_ptjtr_50_100=(TH3D*)file_eff->Get("denom_efficiency_ptjtr_50_100");    
+    
+    TH2D *h2_SVTag_eff_denom_z = (TH2D *)file_eff->Get("h2_SVTag_eff_denom_z");
     TH2D *h2_SVTag_eff_denom = (TH2D *)file_eff->Get("h2_SVTag_eff_denom");
     
     TH1D *h1_recoHF_HFpt = (TH1D *)file_decay->Get("num_efficiency_HFpt");
@@ -422,7 +431,6 @@ void SimpleUnfold(int NumEvts = -1,
     TH3D *h3_ptzjt = new TH3D("ptzjt", "", zbinsize, z_binedges, jtbinsize, jt_binedges, ptbinsize, pt_binedges );
     TH3D *h3_truthptzjt = new TH3D("truthptzjt", "", zbinsize, z_binedges, jtbinsize, jt_binedges, ptbinsize, pt_binedges );
     TH3D *h3_num_efficiency_ptzjt = new TH3D("num_efficiency_ptzjt", "", zbinsize, z_binedges, jtbinsize, jt_binedges, ptbinsize, pt_binedges );
-//    TH3D *h3_denom_efficiency_ptzjt = new TH3D("denom_efficiency_ptzjt", "", zbinsize, z_binedges, jtbinsize, jt_binedges, ptbinsize, pt_binedges );
     TH3D *h3_efficiency_ptzjt = new TH3D("efficiency_ptzjt", "", zbinsize, z_binedges, jtbinsize, jt_binedges, ptbinsize, pt_binedges );
     TH3D *h3_num_purity_ptzjt = new TH3D("num_purity_ptzjt", "", zbinsize, z_binedges, jtbinsize, jt_binedges, ptbinsize, pt_binedges );
     TH3D *h3_denom_purity_ptzjt = new TH3D("denom_purity_ptzjt", "", zbinsize, z_binedges, jtbinsize, jt_binedges, ptbinsize, pt_binedges );
@@ -430,10 +438,19 @@ void SimpleUnfold(int NumEvts = -1,
     
     RooUnfoldResponse *response_ptzjt = new RooUnfoldResponse(h3_ptzjt, h3_truthptzjt, "response_ptzjt");
     
+    TH3D *h3_ptzjt_50_100 = new TH3D("ptzjt_50_100", "", zbinsize_50_100, z_binedges_50_100, jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_truthptzjt_50_100 = new TH3D("truthptzjt_50_100", "", zbinsize_50_100, z_binedges_50_100, jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_num_efficiency_ptzjt_50_100 = new TH3D("num_efficiency_ptzjt_50_100", "", zbinsize_50_100, z_binedges_50_100, jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_efficiency_ptzjt_50_100 = new TH3D("efficiency_ptzjt_50_100", "", zbinsize_50_100, z_binedges_50_100, jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_num_purity_ptzjt_50_100 = new TH3D("num_purity_ptzjt_50_100", "", zbinsize_50_100, z_binedges_50_100, jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_denom_purity_ptzjt_50_100 = new TH3D("denom_purity_ptzjt_50_100", "", zbinsize_50_100, z_binedges_50_100, jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_purity_ptzjt_50_100 = new TH3D("purity_ptzjt_50_100", "", zbinsize_50_100, z_binedges_50_100, jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges );
+    
+    RooUnfoldResponse *response_ptzjt_50_100 = new RooUnfoldResponse(h3_ptzjt_50_100, h3_truthptzjt_50_100, "response_ptzjt_50_100");    
+    
     TH3D *h3_ptzr = new TH3D("ptzr", "",  zbinsize, z_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
     TH3D *h3_truthptzr = new TH3D("truthptzr", "",  zbinsize, z_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
     TH3D *h3_num_efficiency_ptzr = new TH3D("num_efficiency_ptzr", "",  zbinsize, z_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
-//    TH3D *h3_denom_efficiency_ptzr = new TH3D("denom_efficiency_ptzr", "",  zbinsize, z_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
     TH3D *h3_efficiency_ptzr = new TH3D("efficiency_ptzr", "", zbinsize, z_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
     TH3D *h3_num_purity_ptzr = new TH3D("num_purity_ptzr", "",  zbinsize, z_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
     TH3D *h3_denom_purity_ptzr = new TH3D("denom_purity_ptzr", "",  zbinsize, z_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
@@ -441,10 +458,19 @@ void SimpleUnfold(int NumEvts = -1,
     
     RooUnfoldResponse *response_ptzr = new RooUnfoldResponse(h3_ptzr, h3_truthptzr, "response_ptzr");
     
+    TH3D *h3_ptzr_50_100 = new TH3D("ptzr_50_100", "",  zbinsize_50_100, z_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_truthptzr_50_100 = new TH3D("truthptzr_50_100", "",  zbinsize_50_100, z_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_num_efficiency_ptzr_50_100 = new TH3D("num_efficiency_ptzr_50_100", "",  zbinsize_50_100, z_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_efficiency_ptzr_50_100 = new TH3D("efficiency_ptzr_50_100", "", zbinsize_50_100, z_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_num_purity_ptzr_50_100 = new TH3D("num_purity_ptzr_50_100", "",  zbinsize_50_100, z_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_denom_purity_ptzr_50_100 = new TH3D("denom_purity_ptzr_50_100", "",  zbinsize_50_100, z_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_purity_ptzr_50_100 = new TH3D("purity_ptzr_50_100", "",  zbinsize_50_100, z_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    
+    RooUnfoldResponse *response_ptzr_50_100 = new RooUnfoldResponse(h3_ptzr_50_100, h3_truthptzr_50_100, "response_ptzr_50_100");    
+    
     TH3D *h3_ptjtr = new TH3D("ptjtr", "",  jtbinsize, jt_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
     TH3D *h3_truthptjtr = new TH3D("truthptjtr", "", jtbinsize, jt_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
     TH3D *h3_num_efficiency_ptjtr = new TH3D("num_efficiency_ptjtr", "",  jtbinsize, jt_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
-//    TH3D *h3_denom_efficiency_ptjtr = new TH3D("denom_efficiency_ptjtr", "",  jtbinsize, jt_binedges, rbinsize, r_binedges, ptbinsize,  pt_binedges );
     TH3D *h3_efficiency_ptjtr = new TH3D("efficiency_ptjtr", "",  jtbinsize, jt_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
     TH3D *h3_num_purity_ptjtr = new TH3D("num_purity_ptjtr", "",  jtbinsize, jt_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
     TH3D *h3_denom_purity_ptjtr = new TH3D("denom_purity_ptjtr", "", jtbinsize, jt_binedges, rbinsize, r_binedges, ptbinsize, pt_binedges );
@@ -452,11 +478,21 @@ void SimpleUnfold(int NumEvts = -1,
     
     RooUnfoldResponse *response_ptjtr = new RooUnfoldResponse(h3_ptjtr, h3_truthptjtr, "response_ptjtr");
     
+    
+    TH3D *h3_ptjtr_50_100 = new TH3D("ptjtr_50_100", "",  jtbinsize_50_100, jt_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_truthptjtr_50_100 = new TH3D("truthptjtr_50_100", "", jtbinsize_50_100, jt_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_num_efficiency_ptjtr_50_100 = new TH3D("num_efficiency_ptjtr_50_100", "",  jtbinsize_50_100, jt_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_efficiency_ptjtr_50_100 = new TH3D("efficiency_ptjtr_50_100", "",  jtbinsize_50_100, jt_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_num_purity_ptjtr_50_100 = new TH3D("num_purity_ptjtr_50_100", "",  jtbinsize_50_100, jt_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_denom_purity_ptjtr_50_100 = new TH3D("denom_purity_ptjtr_50_100", "", jtbinsize_50_100, jt_binedges_50_100, rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH3D *h3_purity_ptjtr_50_100 = new TH3D("purity_ptjtr_50_100", "", jtbinsize_50_100, jt_binedges_50_100, rbinsize_50_100, r_binedges_50_100,  ptbinsize, pt_binedges );
+    
+    RooUnfoldResponse *response_ptjtr_50_100 = new RooUnfoldResponse(h3_ptjtr_50_100, h3_truthptjtr_50_100, "response_ptjtr_50_100");    
+    
     // 2D Jet_pt vs Observable histograms, Purities/Efficiencies, Responses (359 - 368)
     TH2D *h2_ptz = new TH2D("ptz", "", zbinsize, z_binedges,  ptbinsize, pt_binedges );
     TH2D *h2_truthptz = new TH2D("truthptz", "", zbinsize, z_binedges, ptbinsize, pt_binedges );
     TH2D *h2_num_efficiency_ptz = new TH2D("num_efficiency_ptz", "", zbinsize, z_binedges,  ptbinsize, pt_binedges );
-//    TH2D *h2_denom_efficiency_ptz = new TH2D("denom_efficiency_ptz", "", zbinsize, z_binedges, ptbinsize, pt_binedges );
     TH2D *h2_efficiency_ptz = new TH2D("efficiency_ptz", "", zbinsize, z_binedges,  ptbinsize, pt_binedges );
     TH2D *h2_num_purity_ptz = new TH2D("num_purity_ptz", "", zbinsize, z_binedges, ptbinsize, pt_binedges );
     TH2D *h2_denom_purity_ptz = new TH2D("denom_purity_ptz", "", zbinsize, z_binedges,  ptbinsize, pt_binedges );
@@ -464,10 +500,19 @@ void SimpleUnfold(int NumEvts = -1,
     
     RooUnfoldResponse *response_ptz = new RooUnfoldResponse(h2_ptz, h2_truthptz, "response_ptz");
     
+    TH2D *h2_ptz_50_100 = new TH2D("ptz_50_100", "", zbinsize_50_100, z_binedges_50_100,  ptbinsize, pt_binedges );
+    TH2D *h2_truthptz_50_100 = new TH2D("truthptz_50_100", "", zbinsize_50_100, z_binedges_50_100, ptbinsize, pt_binedges );
+    TH2D *h2_num_efficiency_ptz_50_100 = new TH2D("num_efficiency_ptz_50_100", "", zbinsize_50_100, z_binedges_50_100,  ptbinsize, pt_binedges );
+    TH2D *h2_efficiency_ptz_50_100 = new TH2D("efficiency_ptz_50_100", "", zbinsize_50_100, z_binedges_50_100,  ptbinsize, pt_binedges );
+    TH2D *h2_num_purity_ptz_50_100 = new TH2D("num_purity_ptz_50_100", "", zbinsize_50_100, z_binedges_50_100, ptbinsize, pt_binedges );
+    TH2D *h2_denom_purity_ptz_50_100 = new TH2D("denom_purity_ptz_50_100", "", zbinsize_50_100, z_binedges_50_100,  ptbinsize, pt_binedges );
+    TH2D *h2_purity_ptz_50_100 = new TH2D("purity_ptz_50_100", "", zbinsize_50_100, z_binedges_50_100,  ptbinsize, pt_binedges );
+    
+    RooUnfoldResponse *response_ptz_50_100 = new RooUnfoldResponse(h2_ptz_50_100, h2_truthptz_50_100, "response_ptz_50_100");    
+    
     TH2D *h2_ptjt = new TH2D("ptjt", "", jtbinsize, jt_binedges,  ptbinsize, pt_binedges );
     TH2D *h2_truthptjt = new TH2D("truthptjt", "", jtbinsize, jt_binedges, ptbinsize, pt_binedges );
     TH2D *h2_num_efficiency_ptjt = new TH2D("num_efficiency_ptjt", "", jtbinsize, jt_binedges, ptbinsize, pt_binedges);
-//    TH2D *h2_denom_efficiency_ptjt = new TH2D("denom_efficiency_ptjt", "", jtbinsize, jt_binedges, ptbinsize, pt_binedges);
     TH2D *h2_efficiency_ptjt = new TH2D("efficiency_ptjt", "", jtbinsize, jt_binedges,  ptbinsize, pt_binedges );
     TH2D *h2_num_purity_ptjt = new TH2D("num_purity_ptjt", "", jtbinsize, jt_binedges, ptbinsize, pt_binedges );
     TH2D *h2_denom_purity_ptjt = new TH2D("denom_purity_ptjt", "", jtbinsize, jt_binedges,  ptbinsize, pt_binedges );
@@ -475,16 +520,35 @@ void SimpleUnfold(int NumEvts = -1,
     
     RooUnfoldResponse *response_ptjt = new RooUnfoldResponse(h2_ptjt, h2_truthptjt, "response_ptjt");
     
+    TH2D *h2_ptjt_50_100 = new TH2D("ptjt_50_100", "", jtbinsize_50_100, jt_binedges_50_100,  ptbinsize, pt_binedges );
+    TH2D *h2_truthptjt_50_100 = new TH2D("truthptjt_50_100", "", jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges );
+    TH2D *h2_num_efficiency_ptjt_50_100 = new TH2D("num_efficiency_ptjt_50_100", "", jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges);
+    TH2D *h2_efficiency_ptjt_50_100 = new TH2D("efficiency_ptjt_50_100", "", jtbinsize_50_100, jt_binedges_50_100,  ptbinsize, pt_binedges );
+    TH2D *h2_num_purity_ptjt_50_100 = new TH2D("num_purity_ptjt_50_100", "", jtbinsize_50_100, jt_binedges_50_100, ptbinsize, pt_binedges );
+    TH2D *h2_denom_purity_ptjt_50_100 = new TH2D("denom_purity_ptjt_50_100", "", jtbinsize_50_100, jt_binedges_50_100,  ptbinsize, pt_binedges );
+    TH2D *h2_purity_ptjt_50_100 = new TH2D("purity_ptjt_50_100", "", jtbinsize_50_100, jt_binedges_50_100,  ptbinsize, pt_binedges );
+    
+    RooUnfoldResponse *response_ptjt_50_100 = new RooUnfoldResponse(h2_ptjt_50_100, h2_truthptjt_50_100, "response_ptjt_50_100");    
+    
     TH2D *h2_ptr = new TH2D("ptr", "", rbinsize, r_binedges,  ptbinsize, pt_binedges );
     TH2D *h2_truthptr = new TH2D("truthptr", "", rbinsize, r_binedges, ptbinsize, pt_binedges );
     TH2D *h2_num_efficiency_ptr = new TH2D("num_efficiency_ptr", "", rbinsize, r_binedges, ptbinsize, pt_binedges);
-//    TH2D *h2_denom_efficiency_ptr = new TH2D("denom_efficiency_ptr", "", rbinsize, r_binedges, ptbinsize, pt_binedges);
     TH2D *h2_efficiency_ptr = new TH2D("efficiency_ptr", "", rbinsize, r_binedges,  ptbinsize, pt_binedges );
     TH2D *h2_num_purity_ptr = new TH2D("num_purity_ptr", "", rbinsize, r_binedges, ptbinsize, pt_binedges );
     TH2D *h2_denom_purity_ptr = new TH2D("denom_purity_ptr", "", rbinsize, r_binedges,  ptbinsize, pt_binedges );
     TH2D *h2_purity_ptr = new TH2D("purity_ptr", "", rbinsize, r_binedges,  ptbinsize, pt_binedges );
     
     RooUnfoldResponse *response_ptr = new RooUnfoldResponse(h2_ptr, h2_truthptr, "response_ptr");
+    
+    TH2D *h2_ptr_50_100 = new TH2D("ptr_50_100", "", rbinsize_50_100, r_binedges_50_100,  ptbinsize, pt_binedges );
+    TH2D *h2_truthptr_50_100 = new TH2D("truthptr_50_100", "", rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH2D *h2_num_efficiency_ptr_50_100 = new TH2D("num_efficiency_ptr_50_100", "", rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges);
+    TH2D *h2_efficiency_ptr_50_100 = new TH2D("efficiency_ptr_50_100", "", rbinsize_50_100, r_binedges_50_100,  ptbinsize, pt_binedges );
+    TH2D *h2_num_purity_ptr_50_100 = new TH2D("num_purity_ptr_50_100", "", rbinsize_50_100, r_binedges_50_100, ptbinsize, pt_binedges );
+    TH2D *h2_denom_purity_ptr_50_100 = new TH2D("denom_purity_ptr_50_100", "", rbinsize_50_100, r_binedges_50_100,  ptbinsize, pt_binedges );
+    TH2D *h2_purity_ptr_50_100 = new TH2D("purity_ptr_50_100", "", rbinsize_50_100, r_binedges_50_100,  ptbinsize, pt_binedges );
+    
+    RooUnfoldResponse *response_ptr_50_100 = new RooUnfoldResponse(h2_ptr_50_100, h2_truthptr_50_100, "response_ptr_50_100");    
     
     ////SV tagging
     TH3D *h3_ptzjt_SV = new TH3D("ptzjt_SV", "", zbinsize, z_binedges, jtbinsize, jt_binedges, ptbinsize, pt_binedges );
@@ -947,12 +1011,21 @@ void SimpleUnfold(int NumEvts = -1,
             h2_num_efficiency_zr->Fill(z, r, reweight);
             h2_num_efficiency_jtr->Fill(jt, r, reweight);
             
+                       
             h3_num_efficiency_ptzjt->Fill(tr_z, tr_jt, tr_HFjet.Pt(), reweight);
             h3_num_efficiency_ptzr->Fill(tr_z, tr_r, tr_HFjet.Pt(), reweight);
             h3_num_efficiency_ptjtr->Fill( tr_jt, tr_r, tr_HFjet.Pt(), reweight);
             
             h1_num_purity_jetpt->Fill(jet_pt, reweight);
             h1_num_purity_rap->Fill(jet_rap, reweight);
+            
+            h2_num_efficiency_ptz_50_100->Fill(tr_z, tr_HFjet.Pt(), reweight);
+            h2_num_efficiency_ptjt_50_100->Fill(tr_jt, tr_HFjet.Pt(), reweight);
+            h2_num_efficiency_ptr_50_100->Fill(tr_r, tr_HFjet.Pt(), reweight);
+                                  
+            h3_num_efficiency_ptzjt_50_100->Fill(tr_z, tr_jt, tr_HFjet.Pt(), reweight);
+            h3_num_efficiency_ptzr_50_100->Fill(tr_z, tr_r, tr_HFjet.Pt(), reweight);
+            h3_num_efficiency_ptjtr_50_100->Fill( tr_jt, tr_r, tr_HFjet.Pt(), reweight);            
                                   
         }
         
@@ -986,6 +1059,14 @@ void SimpleUnfold(int NumEvts = -1,
             h3_denom_purity_ptzjt->Fill(z, jt, jet_pt, reweight);
             h3_denom_purity_ptzr->Fill(z, r, jet_pt, reweight);
             h3_denom_purity_ptjtr->Fill(jt, r, jet_pt, reweight);
+            
+            h2_denom_purity_ptz_50_100->Fill(z, jet_pt, reweight);
+            h2_denom_purity_ptjt_50_100->Fill(jt, jet_pt, reweight);
+            h2_denom_purity_ptr_50_100->Fill(r, jet_pt, reweight);
+            
+            h3_denom_purity_ptzjt_50_100->Fill(z, jt, jet_pt, reweight);
+            h3_denom_purity_ptzr_50_100->Fill(z, r, jet_pt, reweight);
+            h3_denom_purity_ptjtr_50_100->Fill(jt, r, jet_pt, reweight);            
             
         }
   /*      
@@ -1025,6 +1106,14 @@ void SimpleUnfold(int NumEvts = -1,
             h3_num_purity_ptzr->Fill(z, r, jet_pt, reweight);
             h3_num_purity_ptjtr->Fill(jt, r, jet_pt, reweight);
             
+            h2_num_purity_ptz_50_100->Fill(z, jet_pt, reweight);
+            h2_num_purity_ptjt_50_100->Fill(jt, jet_pt, reweight);
+            h2_num_purity_ptr_50_100->Fill(r, jet_pt, reweight);
+            
+            h3_num_purity_ptzjt_50_100->Fill(z, jt, jet_pt, reweight);
+            h3_num_purity_ptzr_50_100->Fill(z, r, jet_pt, reweight);
+            h3_num_purity_ptjtr_50_100->Fill(jt, r, jet_pt, reweight);            
+            
             NumTrueBjets++;              
         }
         
@@ -1052,12 +1141,20 @@ void SimpleUnfold(int NumEvts = -1,
         response_zjt->Fill(z, jt, tr_z, tr_jt);
         response_zr->Fill(z, r, tr_z, tr_r);
         response_jtr->Fill(jt, r, tr_jt, tr_r);
+        
         response_ptjt->Fill( jt, jet_pt, tr_jt, tr_jet_pt);
         response_ptr->Fill( r,  jet_pt, tr_r, tr_jet_pt);
         response_ptz->Fill( z,  jet_pt, tr_z, tr_jet_pt);
         response_ptzjt->Fill( z, jt, jet_pt, tr_z, tr_jt, tr_jet_pt);
         response_ptzr->Fill( z, r, jet_pt, tr_z, tr_r, tr_jet_pt);
         response_ptjtr->Fill( jt,  r, jet_pt, tr_jt, tr_r, tr_jet_pt);
+        
+        response_ptjt_50_100->Fill( jt, jet_pt, tr_jt, tr_jet_pt);
+        response_ptr_50_100->Fill( r,  jet_pt, tr_r, tr_jet_pt);
+        response_ptz_50_100->Fill( z,  jet_pt, tr_z, tr_jet_pt);
+        response_ptzjt_50_100->Fill( z, jt, jet_pt, tr_z, tr_jt, tr_jet_pt);
+        response_ptzr_50_100->Fill( z, r, jet_pt, tr_z, tr_r, tr_jet_pt);
+        response_ptjtr_50_100->Fill( jt,  r, jet_pt, tr_jt, tr_r, tr_jet_pt);        
         
         
         // if(jet_pt > ptMax) continue;
@@ -1118,9 +1215,17 @@ void SimpleUnfold(int NumEvts = -1,
     response_ptr->Write( "Roo_response_ptr");
     response_ptz->Write("Roo_response_ptz" );
         
-    response_ptzjt->Write("Roo_response_ptzjt" );
+    response_ptzjt->Write("Roo_response_ptzjt");
     response_ptzr->Write( "Roo_response_ptzr");
-    response_ptjtr->Write( "Roo_response_ptjtr") ;
+    response_ptjtr->Write( "Roo_response_ptjtr");
+    
+    response_ptjt_50_100->Write("Roo_response_ptjt_50_100");
+    response_ptr_50_100->Write( "Roo_response_ptr_50_100");
+    response_ptz_50_100->Write("Roo_response_ptz_50_100" );
+        
+    response_ptzjt_50_100->Write("Roo_response_ptzjt_50_100");
+    response_ptzr_50_100->Write( "Roo_response_ptzr_50_100");
+    response_ptjtr_50_100->Write( "Roo_response_ptjtr_50_100") ;    
 
 //          TEfficiency *h1_purity_z = new TEfficiency(*h1_num_purity_z, *h1_denom_purity_z);
         
@@ -1183,13 +1288,44 @@ void SimpleUnfold(int NumEvts = -1,
     
     h1_efficiency_z->Divide(h1_num_efficiency_z, h1_denom_efficiency_z, 1, 1, "B");     
     h1_efficiency_jt->Divide(h1_num_efficiency_jt, h1_denom_efficiency_jt, 1, 1, "B");     
-    h1_efficiency_r->Divide(h1_num_efficiency_r, h1_denom_efficiency_r, 1, 1, "B");                                   
+    h1_efficiency_r->Divide(h1_num_efficiency_r, h1_denom_efficiency_r, 1, 1, "B");   
+                                    
     h2_efficiency_ptz->Divide(h2_num_efficiency_ptz, h2_denom_efficiency_ptz, 1, 1, "B");    
     h2_efficiency_ptjt->Divide(h2_num_efficiency_ptjt, h2_denom_efficiency_ptjt, 1, 1, "B");    
     h2_efficiency_ptr->Divide(h2_num_efficiency_ptr, h2_denom_efficiency_ptr, 1, 1, "B");    
+    
     h2_purity_ptz->Divide(h2_num_purity_ptz, h2_denom_purity_ptz, 1, 1, "B");     
     h2_purity_ptjt->Divide(h2_num_purity_ptjt, h2_denom_purity_ptjt, 1, 1, "B"); 
     h2_purity_ptr->Divide(h2_num_purity_ptr, h2_denom_purity_ptr, 1, 1, "B");
+    
+    h3_efficiency_ptzjt->Divide(h3_num_efficiency_ptzjt, h3_denom_efficiency_ptzjt, 1, 1, "B");
+    h3_efficiency_ptzr->Divide(h3_num_efficiency_ptzr, h3_denom_efficiency_ptzr, 1, 1, "B");
+    h3_efficiency_ptjtr->Divide(h3_num_efficiency_ptjtr, h3_denom_efficiency_ptjtr, 1, 1, "B");    
+    
+    h3_purity_ptzjt->Divide(h3_num_purity_ptzjt, h3_denom_purity_ptzjt, 1, 1, "B");    
+    h3_purity_ptzr->Divide(h3_num_purity_ptzr, h3_denom_purity_ptzr, 1, 1, "B");
+    h3_purity_ptjtr->Divide(h3_num_purity_ptjtr, h3_denom_purity_ptjtr, 1, 1, "B");    
+    
+    h2_efficiency_ptz_50_100->Divide(h2_num_efficiency_ptz_50_100, h2_denom_efficiency_ptz_50_100, 1, 1, "B");    
+    h2_efficiency_ptjt_50_100->Divide(h2_num_efficiency_ptjt_50_100, h2_denom_efficiency_ptjt_50_100, 1, 1, "B");    
+    h2_efficiency_ptr_50_100->Divide(h2_num_efficiency_ptr_50_100, h2_denom_efficiency_ptr_50_100, 1, 1, "B");    
+    
+    h2_purity_ptz_50_100->Divide(h2_num_purity_ptz_50_100, h2_denom_purity_ptz_50_100, 1, 1, "B");     
+    h2_purity_ptjt_50_100->Divide(h2_num_purity_ptjt_50_100, h2_denom_purity_ptjt_50_100, 1, 1, "B"); 
+    h2_purity_ptr_50_100->Divide(h2_num_purity_ptr_50_100, h2_denom_purity_ptr_50_100, 1, 1, "B");
+    
+    h3_efficiency_ptzjt_50_100->Divide(h3_num_efficiency_ptzjt_50_100, h3_denom_efficiency_ptzjt_50_100, 1, 1, "B");
+    h3_efficiency_ptzr_50_100->Divide(h3_num_efficiency_ptzr_50_100, h3_denom_efficiency_ptzr_50_100, 1, 1, "B");
+    h3_efficiency_ptjtr_50_100->Divide(h3_num_efficiency_ptjtr_50_100, h3_denom_efficiency_ptjtr_50_100, 1, 1, "B");    
+    
+    h3_purity_ptzjt_50_100->Divide(h3_num_purity_ptzjt_50_100, h3_denom_purity_ptzjt_50_100, 1, 1, "B");    
+    h3_purity_ptzr_50_100->Divide(h3_num_purity_ptzr_50_100, h3_denom_purity_ptzr_50_100, 1, 1, "B");
+    h3_purity_ptjtr_50_100->Divide(h3_num_purity_ptjtr_50_100, h3_denom_purity_ptjtr_50_100, 1, 1, "B");        
+      
+    h3_efficiency_ptzjt_SV->Divide(h3_num_efficiency_ptzjt_SV, h3_denom_efficiency_ptzjt_SV, 1, 1, "B");
+    h3_purity_ptzr_SV->Divide(h3_num_purity_ptzr_SV, h3_denom_purity_ptzr_SV, 1, 1, "B");
+    
+    h3_efficiency_ptjtr_SV->Divide(h3_num_efficiency_ptjtr_SV, h3_denom_efficiency_ptjtr_SV, 1, 1, "B");    
     
  
     TH2D *h2_efficiency_HFpteta = (TH2D *)h2_num_efficiency_HFpteta->Clone("h2_efficiency_HFpteta");
@@ -1216,20 +1352,6 @@ void SimpleUnfold(int NumEvts = -1,
     TH1D *h1_efficiency_recoJet_jetpt = (TH1D *)h1_num_efficiency_jetpt->Clone("efficiency_recoJet_jetpt");
     h1_efficiency_recoJet_jetpt->Divide(h1_efficiency_recoJet_jetpt, h1_recoHF_jetpt, 1, 1, "B");
         
-    
-    h3_efficiency_ptzjt->Divide(h3_num_efficiency_ptzjt, h3_denom_efficiency_ptzjt, 1, 1, "B");
-    h3_purity_ptzjt->Divide(h3_num_purity_ptzjt, h3_denom_purity_ptzjt, 1, 1, "B");
-    
-    h3_efficiency_ptzr->Divide(h3_num_efficiency_ptzr, h3_denom_efficiency_ptzr, 1, 1, "B");
-    h3_purity_ptzr->Divide(h3_num_purity_ptzr, h3_denom_purity_ptzr, 1, 1, "B");
-    
-    h3_efficiency_ptjtr->Divide(h3_num_efficiency_ptjtr, h3_denom_efficiency_ptjtr, 1, 1, "B");
-    h3_purity_ptjtr->Divide(h3_num_purity_ptjtr, h3_denom_purity_ptjtr, 1, 1, "B");
-      
-    h3_efficiency_ptzjt_SV->Divide(h3_num_efficiency_ptzjt_SV, h3_denom_efficiency_ptzjt_SV, 1, 1, "B");
-    h3_purity_ptzr_SV->Divide(h3_num_purity_ptzr_SV, h3_denom_purity_ptzr_SV, 1, 1, "B");
-    
-    h3_efficiency_ptjtr_SV->Divide(h3_num_efficiency_ptjtr_SV, h3_denom_efficiency_ptjtr_SV, 1, 1, "B");
         
 //      h2_purity_zjt->Write("purity_zjt");
 //      h2_purity_zr->Write("purity_zr");
@@ -1259,6 +1381,22 @@ void SimpleUnfold(int NumEvts = -1,
     h3_purity_ptzjt->Write("purity_ptzjt");
     h3_purity_ptzr->Write("purity_ptzr");
     h3_purity_ptjtr->Write("purity_ptjtr");
+    
+    h2_efficiency_ptz_50_100->Write("efficiency_ptz_50_100");
+    h2_efficiency_ptjt_50_100->Write("efficiency_ptjt_50_100");
+    h2_efficiency_ptr_50_100->Write("efficiency_ptr_50_100");
+    
+    h2_purity_ptz_50_100->Write("purity_ptz_50_100");
+    h2_purity_ptjt_50_100->Write("purity_ptjt_50_100");
+    h2_purity_ptr_50_100->Write("purity_ptr_50_100");
+    
+    h3_efficiency_ptzjt_50_100->Write("efficiency_ptzjt_50_100");
+    h3_efficiency_ptzr_50_100->Write("efficiency_ptzr_50_100");
+    h3_efficiency_ptjtr_50_100->Write("efficiency_ptjtr_50_100");
+    
+    h3_purity_ptzjt_50_100->Write("purity_ptzjt_50_100");
+    h3_purity_ptzr_50_100->Write("purity_ptzr_50_100");
+    h3_purity_ptjtr_50_100->Write("purity_ptjtr_50_100");    
         
     h2_efficiency_HFpteta->Write("efficiency_HFpteta");
     h3_efficiency_HFptetajetpt->Write("efficiency_HFptetajetpt");


### PR DESCRIPTION
Add additional binning scheme for 50<pt<100 and corresponding correction histograms. Add HFpt vs. (z,jt,r) correlation plots in SimpleObservables. The results are pretty striking for HFpt vs. z.

![image](https://github.com/user-attachments/assets/4a31abb3-73d1-4c30-9325-3469c3a38a43)
